### PR TITLE
Allow break-at to be configured

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   testProject:
     description: "The path to the test project directory (e.g. BusinessLogic.Test/)"
     required: true
+  breakAt:
+    description: "When threshold break is set to anything other than 0 and the mutation score is lower than the threshold Stryker will exit with a non-zero code."
+    required: false
+    default: "0"
 
 outputs:
   htmlReport:
@@ -18,3 +22,4 @@ runs:
   image: 'dockerfile'
   args:
     - ${{ inputs.testProject }}
+    - ${{ inputs.breakAt }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ echo "Changing direcotry to $testProject"
 cd $testProject
 
 echo "Starting Striker.NET run"
-dotnet stryker
+dotnet stryker --break-at $2


### PR DESCRIPTION
Allow the break at configuration option to be configured, to fail the build when the mutation score is below the configured value. The default value is configured as `0`.